### PR TITLE
split only on first = occurrence

### DIFF
--- a/lib/FargateHelper.js
+++ b/lib/FargateHelper.js
@@ -18,7 +18,7 @@ class FargateHelper {
 			const key = keyString.slice(2);
 
 			if (key == "env") {
-				const keyValue = value.split("=");
+				const keyValue = value.split(/=(.+)/);
 				const envKey = keyValue[0];
 				options.env[envKey] = keyValue[1];
 			} else if (key == "envFile") {


### PR DESCRIPTION
to avoid cutting keys that contains = characters