### PR TITLE
EC2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ fargate service \
 Example (creates or updates the scheduled task `my-scheduled-task` with the specified parameters):
 ```
 fargate schedule \
-        --command "node lib/service.js" \
-        --cpu 1024 \
-        --env key=value \
-        --image bespoken/my-service-image \
-        --memory 2048 \
-        --cron "cron(0 12 * * ? *)" \
-        --name my-scheduled-task
+  --command "node lib/service.js" \
+  --cpu 1024 \
+  --env key=value \
+  --image bespoken/my-service-image \
+  --memory 2048 \
+  --cron "cron(0 12 * * ? *)" \
+  --name my-scheduled-task
 ```
 
 For `create`, the script will:  
@@ -93,6 +93,7 @@ Though not required, these are useful parameters for more advanced cases:
 * env: Key-value pair that is passed to the TaskDefition/container runtime
 * envFile: The relative path to a file that contains environment settings - set inside the TaskDefinition/container runtime
 * hostname: The fully-qualified hostname for the service - i.e., "service.bespoken.tools". When the default <SERVICE>.bespoken.io is not appropriate.
+* launchType: The launchType of the service and requiredCompatibilities of the task definition. Values can be EC2 | FARGATE. Defaults to FARGATE.
 * logGroup: The CloudWatch Log Group to use - defaults to `fargate-cluster`
 * passEnv: "true" or "false" - defaults to true. If set to false, will not automatically set pass thru environment variables in the build environment to the container environment
 * taskDefinition: A file to use as the baseline for the taskDefinition - if not specified, just uses the default that is included in the code
@@ -126,13 +127,17 @@ These are values that are generally universal for the account - these should not
 They can be found under the name "fargate-helper". Values we store there are:
 * accountId: The AWS account ID
 * albArn: The ARN for the ALB being used for this account
-* cluster: The fargate cluster name
+* cluster: The short name or full Amazon Resource Name (ARN) of the cluster on which to run your service.
+* clusterArn: Used for scheduled tasks, can only be an ARN. **TODO:** Unify with the cluster param.
 * dockerHubSecretArn: The name of the AWS Secret that stores our docker credentials
 * listenerArn: The ARN for the ALB listener being used for this account
 * roleArn: Used for taskRoleArn and executionRoleArn
 * securityGroup: The VPC security group to use
 * subnets: The list of subnets to use
 * vpcId: The VPC ID used by this configuration - specified when creating the target group on the ALB
+
+## EC2 Considerations
+By changing the `launchType` parameter to 'EC2' we can leverage all the current functionality and deploy to EC2, provided that the EC2 instances already exist on the target ECS cluster. 
 
 # Runtime Configuration
 Environment variables can also be set inside the running container.

--- a/TaskDefinition.base.json
+++ b/TaskDefinition.base.json
@@ -34,7 +34,7 @@
     "memory": "${memory}",
 	"networkMode": "awsvpc",
     "requiresCompatibilities": [
-        "FARGATE"
+        "${launchType}"
 	],
 	"taskRoleArn": "${roleArn}"
 }

--- a/lib/ECSManager.js
+++ b/lib/ECSManager.js
@@ -13,7 +13,7 @@ class ECSManager {
 		const serviceInfo = {
 			cluster: Config.str("cluster"),
 			desiredCount: Config.int("desiredCounted", 1),
-			launchType: "FARGATE",
+			launchType: Config.str("launchType"),
 			loadBalancers: [
 				{
 					containerName: Config.str("serviceName"),
@@ -82,6 +82,7 @@ class ECSManager {
 		taskDefinitionString = Util.substitute(taskDefinitionString, "cpu", Config.str("cpu"));
 		taskDefinitionString = Util.substitute(taskDefinitionString, "dockerHubSecretArn", Config.str("dockerHubSecretArn"));
 		taskDefinitionString = Util.substitute(taskDefinitionString, "image", Config.str("image"));
+		taskDefinitionString = Util.substitute(taskDefinitionString, "launchType", Config.str("launchType"));
 		taskDefinitionString = Util.substitute(taskDefinitionString, "logGroup", Config.str("logGroup", "fargate-cluster"));
 		taskDefinitionString = Util.substitute(taskDefinitionString, "memory", Config.str("memory"));
 		taskDefinitionString = Util.substitute(taskDefinitionString, "roleArn", Config.str("roleArn"));

--- a/lib/FargateHelper.js
+++ b/lib/FargateHelper.js
@@ -29,10 +29,10 @@ class FargateHelper {
 					if (line.trim().indexOf("=") === -1) {
 						continue;
 					}
-
-					const keyValue = line.trim().split("=");
+					const trimmed = line.trim();
+					const keyValue = trimmed.split("=");
 					const envKey = keyValue[0];
-					options.env[envKey] = keyValue[1];
+					options.env[envKey] = trimmed.substring(envKey.length+1);
 				}
 			} else {
 				options[key] = value;

--- a/lib/FargateHelper.js
+++ b/lib/FargateHelper.js
@@ -29,10 +29,9 @@ class FargateHelper {
 					if (line.trim().indexOf("=") === -1) {
 						continue;
 					}
-					const trimmed = line.trim();
-					const keyValue = trimmed.split("=");
+					const keyValue = line.trim().split(/=(.+)/);
 					const envKey = keyValue[0];
-					options.env[envKey] = trimmed.substring(envKey.length+1);
+					options.env[envKey] = keyValue[1];
 				}
 			} else {
 				options[key] = value;


### PR DESCRIPTION
- Added `launchType` to our Secrets Manager.
- Added `launchType` as a parameter. Defaults to `FARGATE`. It goes both into the service's `launchType` as well as the TaskDefinition's `requiredCompatibilities` properties.
- Fixed an issue on reading the env parameters. Values that had "=" on them would not be set correctly on the container.
- Modified the README file with these changes.

Relates to #11 